### PR TITLE
fix: Remove redundant LanguageProvider from App.tsx

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,13 +28,11 @@ function Router() {
   );
 }
 
-import { LanguageProvider } from "./contexts/LanguageContext";
-
 function App() {
   return (
     <ErrorBoundary>
       <ThemeProvider defaultTheme="light">
-        <LanguageProvider>
+        
         <TooltipProvider>
           <Toaster />
           <Header />
@@ -42,7 +40,7 @@ function App() {
             <Router />
           </main>
         </TooltipProvider>
-        </LanguageProvider>
+        
       </ThemeProvider>
     </ErrorBoundary>
   );


### PR DESCRIPTION
The LanguageProvider was being imported and used in both main.tsx and App.tsx, leading to a potential conflict or incorrect initialization which is likely the cause of the 'TypeError: n is not a function' in the minified production bundle. This commit removes the redundant usage from App.tsx.