### PR TITLE
Fix: Correctly resolve nested i18n keys

### DIFF
--- a/client/src/contexts/LanguageContext.tsx
+++ b/client/src/contexts/LanguageContext.tsx
@@ -14,7 +14,7 @@ const getTranslation = (key: string, lang: Language): string => {
   const keys = key.split('.');
   let result: any = translations[lang];
   for (const k of keys) {
-    if (result && result[k] !== undefined) {
+    if (result && typeof result === 'object' && k in result) {
       result = result[k];
     } else {
       return key; // Return the key itself if translation is missing


### PR DESCRIPTION
This PR fixes the issue where translation keys were not resolving correctly due to an error in the recursive lookup logic in LanguageContext.tsx.